### PR TITLE
fix: install local package

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,3 +11,5 @@ sphinx:
 python:
   install:
     - requirements: docs/requirements.txt
+    - method: pip
+      path: .


### PR DESCRIPTION
We need to install the local python package in order to build the docs on Read The Docs.